### PR TITLE
Fixing input size issue in IE10

### DIFF
--- a/src/javascript/runtime/html5/file/FileInput.js
+++ b/src/javascript/runtime/html5/file/FileInput.js
@@ -37,7 +37,7 @@ define("moxie/runtime/html5/file/FileInput", [
 
 				shimContainer = I.getShimContainer();
 
-				shimContainer.innerHTML = '<input id="' + I.uid +'" type="file" style="font-size:999px;opacity:0;"' +
+				shimContainer.innerHTML = '<input id="' + I.uid +'" type="file" style="font-size:999px;opacity:0;width:100%;height:100%;"' +
 					(options.multiple && I.can('select_multiple') ? 'multiple="multiple"' : '') + ' accept="' + mimes.join(',') + '" />';
 
 				input = Dom.get(I.uid);


### PR DESCRIPTION
IE10 on Windows 8 doesn't get (from moxie) the width and height 100% inline properties that other browsers do, not sure why.
This causes the file selector not to open when clicking the majority of the button if you have a large button.
This fix adds the 100% properties inline by default.

No 100% width/height:
![Screen Shot 2013-03-04 at 17 41 32](https://f.cloud.github.com/assets/711132/217694/26be15ae-84f3-11e2-8765-9c28a00c9b58.png)

100% width/height:
![Screen Shot 2013-03-04 at 17 43 15](https://f.cloud.github.com/assets/711132/217695/26b74274-84f3-11e2-8e28-4de30f5f31f8.png)