### PR TITLE
Send completion event when using 'non-native' XHR

### DIFF
--- a/src/javascript/xhr/XMLHttpRequest.js
+++ b/src/javascript/xhr/XMLHttpRequest.js
@@ -941,6 +941,7 @@ define("moxie/xhr/XMLHttpRequest", [
 						if (_upload_events_flag) {
 							self.upload.dispatchEvent(e);
 						}
+						self.dispatchEvent('readystatechange');
 						self.dispatchEvent(e);
 					} else {
 						_error_flag = true;


### PR DESCRIPTION
When using a "non-native" XHR runtime (even HTML5 XHR which really is native) the "readystatechange" callback is not called when the transfer is complete. This patch fixes this problem.
