### PR TITLE
Avoid security error due to accessing headers not allowed.

### DIFF
--- a/src/javascript/xhr/XMLHttpRequest.js
+++ b/src/javascript/xhr/XMLHttpRequest.js
@@ -827,7 +827,9 @@ define("moxie/xhr/XMLHttpRequest", [
 					// looks like HEADERS_RECEIVED (state 2) is not reported in Opera (or it's old versions), hence we can't really use it
 					case XMLHttpRequest.HEADERS_RECEIVED:
 						try {
-							total = _xhr.getResponseHeader('Content-Length') || 0; // old Safari throws an exception here
+							if (_same_origin_flag) { // Content-Length not accessible for cross-domain on some browsers
+								total = _xhr.getResponseHeader('Content-Length') || 0; // old Safari throws an exception here
+							}
 						} catch(ex) {}
 						break;
 						


### PR DESCRIPTION
Browsers restrict access to all headers on cross-domain requests to
headers other than the "simple response headers". If not a simple handle
browsers handle header access in inconsistant ways. Some even throw and error
that you cannot try-catch. The conditional in this commit prevents the
error from occuring on cross-domain requests.

See http://stackoverflow.com/a/4858984/120067 for more info
