### PR TITLE
Force runtimes to handle x-domain. Explicit flag to indicate support

### DIFF
--- a/src/javascript/runtime/Runtime.js
+++ b/src/javascript/runtime/Runtime.js
@@ -93,7 +93,9 @@ define('moxie/runtime/Runtime', [
 			upload_filesize: true,
 			// ... initiate http request with specific http method, method should be passed as argument
 			// e.g. runtime.can('use_http_method', 'put')
-			use_http_method: true
+			use_http_method: true,
+			// ... the request will be cross domain
+			cross_domain: true
 		}, caps);
 
 		

--- a/src/javascript/runtime/flash/Runtime.js
+++ b/src/javascript/runtime/flash/Runtime.js
@@ -77,7 +77,8 @@ define("moxie/runtime/flash/Runtime", [
 				},
 				use_http_method: function(methods) {
 					return !Basic.arrayDiff(methods, ['GET', 'POST']);
-				}
+				},
+				cross_domain: true
 			};
 		}()));
 

--- a/src/javascript/runtime/html4/Runtime.js
+++ b/src/javascript/runtime/html4/Runtime.js
@@ -59,7 +59,8 @@ define("moxie/runtime/html4/Runtime", [
 			upload_filesize: true,
 			use_http_method: function(methods) {
 				return !Basic.arrayDiff(methods, ['GET', 'POST']);
-			}
+			},
+			cross_domain: true
 		});
 
 		Basic.extend(this, {

--- a/src/javascript/runtime/html5/Runtime.js
+++ b/src/javascript/runtime/html5/Runtime.js
@@ -71,7 +71,10 @@ define("moxie/runtime/html5/Runtime", [
 						(Env.browser === 'Opera' && Env.version >= 12)	||
 						!!~Basic.inArray(Env.browser, ['Chrome', 'Safari']);
 			}()),
-			upload_filesize: true
+			upload_filesize: true,
+			cross_domain: (function() {
+				return 'withCredentials' in new window.XMLHttpRequest();
+			})()
 		});
 
 

--- a/src/javascript/xhr/XMLHttpRequest.js
+++ b/src/javascript/xhr/XMLHttpRequest.js
@@ -1008,6 +1008,7 @@ define("moxie/xhr/XMLHttpRequest", [
 		}
 
 		function _canUseNativeXHR() {
+			if (!_same_origin_flag) return false
 			return _method === 'HEAD' ||
 					(_method === 'GET' && !!~Basic.inArray(_p('responseType'), ["", "text", "document"])) ||
 					(_method === 'POST' && _headers['Content-Type'] === 'application/x-www-form-urlencoded');


### PR DESCRIPTION
This is to resolve my issues on Issue #21.

Note: I kept with a simple check for CORS and didn't bother with XDomainRequest. If we incorporated XDomainRequest we could pick up IE 8 and 9 support but XDomainRequest has a bunch of odd restrictions (only plain text, only GET and POST, etc.). So I stuck with just browsers that support the latest standard. I figure IE 8 and 9 can fallback on Flash.
