### PR TITLE
Drag & Drop problem if file name contains special characters

### DIFF
--- a/src/javascript/runtime/html5/file/FileDrop.js
+++ b/src/javascript/runtime/html5/file/FileDrop.js
@@ -47,7 +47,14 @@ define("moxie/runtime/html5/file/FileDrop", [
 					if (e.dataTransfer.items && e.dataTransfer.items[0].webkitGetAsEntry) {
 						var entries = [];
 						Basic.each(e.dataTransfer.items, function(item) {
-							entries.push(item.webkitGetAsEntry());
+							var entry = item.webkitGetAsEntry();
+							if (entry.isFile) {
+							  // file() fails on OSX when the file contains a special character (eg. umlaut)
+								entry.file = function(success) {
+									success(item.getAsFile());
+								};
+							}
+							entries.push(entry);
 						});
 						_readEntries(entries, function() {
 							comp.trigger("drop");


### PR DESCRIPTION
In Chrome on OSX if you drag & drop a file with a name that contains umlauts (eg. "über_cool.jpg") then moxie silently fails to get the native file object (`webkitGetAsEntry().file()`).
This seems to happen because of a chrome bug.
The attached code will work around this issue by using `getAsFile` on the dataTransfer item.
