### PR TITLE
Fix ArgumentError and ReferenceError

### DIFF
--- a/src/flash/src/com/Blob.as
+++ b/src/flash/src/com/Blob.as
@@ -195,7 +195,7 @@ package com
 		}
 		
 		
-		public function destroy() : void
+		public function destroy(obj:* = null) : void
 		{			
 			for each (var src:Object in _sources) {
 				if (--src.buffer.refs <= 0) {

--- a/src/flash/src/com/utils/Buffer.as
+++ b/src/flash/src/com/utils/Buffer.as
@@ -47,7 +47,7 @@ package com.utils
 		
 		
 		public function purge() : void {
-			if (_fileRef && _fileRef.data.length) {
+			if (_fileRef && _fileRef.data && _fileRef.data.length) {
 				_fileRef.data.clear();
 			}
 		}


### PR DESCRIPTION
- Blob destroy() expects a parameter; copied from Silverlight.
- Checking for _fileRef.data, not just _fileRef.
