### PR TITLE
Updated check for IE to also check for IEMobile (Fixes WP8.1)

### DIFF
--- a/src/javascript/runtime/html5/file/FileInput.js
+++ b/src/javascript/runtime/html5/file/FileInput.js
@@ -111,7 +111,7 @@ define("moxie/runtime/html5/file/FileInput", [
 					}
 
 					// clearing the value enables the user to select the same file again if they want to
-					if (Env.browser !== 'IE') {
+					if (Env.browser !== 'IE' && Env.browser !== 'IEMobile') {
 						this.value = '';
 					} else {
 						// in IE input[type="file"] is read-only so the only way to reset it is to re-insert it


### PR DESCRIPTION
Windows phone 8.1 has been released to developers, and now supports uploading images from the browser. This small fix allows plupload to work on windows phone 8.1
