### PR TITLE
Fix bower.json syntax

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,10 +9,10 @@
 		"./bin/silverlight/Moxie.min.xap"
 	],
 	"ignore": [
-		"tests/"
-		"src/"
-		"build/"
-		"Jakefile.js"
+		"tests/",
+		"src/",
+		"build/",
+		"Jakefile.js",
 		"package.json",
 		"bower.json",
 		"README.md",


### PR DESCRIPTION
master branch currently isn't installable with Bower, you get the error

```
bower EMALFORMED    Failed to read …/.bower/tmp/moxie-9044-3kdiGq/bower.json

Additional error details:
Unexpected string
```
