### PR TITLE
Multiple selection ability - wrong iOS detection

### DIFF
--- a/src/javascript/runtime/html5/Runtime.js
+++ b/src/javascript/runtime/html5/Runtime.js
@@ -67,9 +67,9 @@ define("moxie/runtime/html5/Runtime", [
 				},
 				select_multiple: function() {
 					// it is buggy on Safari Windows and iOS
-					return I.can('select_file') && 
-						!(Env.browser === 'Safari' && Env.os === 'Windows') && 
-						!(Env.os === 'iOS' && Env.verComp(Env.osVersion, "7.0.0", '>'));
+					return I.can('select_file') &&
+						!(Env.browser === 'Safari' && Env.os === 'Windows') &&
+						!(Env.os === 'iOS' && Env.verComp(Env.osVersion, "7.0.0", '>') && Env.verComp(Env.osVersion, "8.0.0", '<'));
 				},
 				send_binary_string: Test(window.XMLHttpRequest && (new XMLHttpRequest().sendAsBinary || (window.Uint8Array && window.ArrayBuffer))),
 				send_custom_headers: Test(window.XMLHttpRequest),

--- a/src/javascript/runtime/html5/Runtime.js
+++ b/src/javascript/runtime/html5/Runtime.js
@@ -69,7 +69,7 @@ define("moxie/runtime/html5/Runtime", [
 					// it is buggy on Safari Windows and iOS
 					return I.can('select_file') && 
 						!(Env.browser === 'Safari' && Env.os === 'Windows') && 
-						!(Env.os === 'iOS' && Env.verComp(Env.osVersion, "7.0.4", '<'));
+						!(Env.os === 'iOS' && Env.verComp(Env.osVersion, "7.0.0", '>'));
 				},
 				send_binary_string: Test(window.XMLHttpRequest && (new XMLHttpRequest().sendAsBinary || (window.Uint8Array && window.ArrayBuffer))),
 				send_custom_headers: Test(window.XMLHttpRequest),


### PR DESCRIPTION
There is a bug in iOS 7.0.x and even on iOS 7.1.x , that results in inability to upload a video when `multiple_selection` in Plupload is set to `true`. All works fine in iOS 6.x and below.

The current check was considering all iOS versions smaller than 7.0.4 as broken. I've made a change to make all iOS 7.x versions as broken instead.

P.S.
Before this fix it's impossible to upload a video on iOS 7.0.6 and iOS 7.1.2 on iPhone 5S.