### PR TITLE
Add extensions to accepts attribute for html5

### DIFF
--- a/src/javascript/core/utils/Mime.js
+++ b/src/javascript/core/utils/Mime.js
@@ -115,6 +115,9 @@ define("moxie/core/utils/Mime", [
 						}
 					} else if (Basic.inArray(type, mimes) === -1) {
 						mimes.push(type);
+						if (addMissingExtensions && /^\w+$/.test(ext[ii])) {
+							mimes.push('.' + ext[ii]);
+						}
 					}
 				}
 			}

--- a/src/javascript/core/utils/Mime.js
+++ b/src/javascript/core/utils/Mime.js
@@ -12,7 +12,7 @@ define("moxie/core/utils/Mime", [
 	"moxie/core/utils/Basic",
 	"moxie/core/I18n"
 ], function(Basic, I18n) {
-	
+
 	var mimeData = "" +
 		"application/msword,doc dot," +
 		"application/pdf,pdf," +
@@ -63,12 +63,12 @@ define("moxie/core/utils/Mime", [
 		"video/3gpp,3gpp 3gp," +
 		"video/3gpp2,3g2," +
 		"video/vnd.rn-realvideo,rv," +
-		"video/ogg,ogv," + 
+		"video/ogg,ogv," +
 		"video/x-matroska,mkv," +
 		"application/vnd.oasis.opendocument.formula-template,otf," +
 		"application/octet-stream,exe";
-	
-	
+
+
 	var Mime = {
 
 		mimes: {},
@@ -78,7 +78,7 @@ define("moxie/core/utils/Mime", [
 		// Parses the default mime types string into a mimes and extensions lookup maps
 		addMimeType: function (mimeData) {
 			var items = mimeData.split(/,/), i, ii, ext;
-			
+
 			for (i = 0; i < items.length; i += 2) {
 				ext = items[i + 1].split(/ /);
 
@@ -94,18 +94,18 @@ define("moxie/core/utils/Mime", [
 
 		extList2mimes: function (filters, addMissingExtensions) {
 			var self = this, ext, i, ii, type, mimes = [];
-			
+
 			// convert extensions to mime types list
 			for (i = 0; i < filters.length; i++) {
 				ext = filters[i].extensions.split(/\s*,\s*/);
 
 				for (ii = 0; ii < ext.length; ii++) {
-					
+
 					// if there's an asterisk in the list, then accept attribute is not required
 					if (ext[ii] === '*') {
 						return [];
 					}
-					
+
 					type = self.mimes[ext[ii]];
 					if (!type) {
 						if (addMissingExtensions && /^\w+$/.test(ext[ii])) {
@@ -115,9 +115,6 @@ define("moxie/core/utils/Mime", [
 						}
 					} else if (Basic.inArray(type, mimes) === -1) {
 						mimes.push(type);
-						if (addMissingExtensions && /^\w+$/.test(ext[ii])) {
-							mimes.push('.' + ext[ii]);
-						}
 					}
 				}
 			}
@@ -127,7 +124,7 @@ define("moxie/core/utils/Mime", [
 
 		mimes2exts: function(mimes) {
 			var self = this, exts = [];
-			
+
 			Basic.each(mimes, function(mime) {
 				if (mime === '*') {
 					exts = [];
@@ -137,7 +134,7 @@ define("moxie/core/utils/Mime", [
 				// check if this thing looks like mime type
 				var m = mime.match(/^(\w+)\/(\*|\w+)$/);
 				if (m) {
-					if (m[2] === '*') { 
+					if (m[2] === '*') {
 						// wildcard mime type detected
 						Basic.each(self.extensions, function(arr, mime) {
 							if ((new RegExp('^' + m[1] + '/')).test(mime)) {
@@ -161,12 +158,12 @@ define("moxie/core/utils/Mime", [
 			}
 
 			exts = this.mimes2exts(mimes);
-			
+
 			accept.push({
 				title: I18n.translate('Files'),
 				extensions: exts.length ? exts.join(',') : '*'
 			});
-			
+
 			// save original mimes string
 			accept.mimes = mimes;
 

--- a/src/javascript/runtime/html4/Runtime.js
+++ b/src/javascript/runtime/html4/Runtime.js
@@ -22,7 +22,7 @@ define("moxie/runtime/html4/Runtime", [
 	"moxie/runtime/Runtime",
 	"moxie/core/utils/Env"
 ], function(Basic, x, Runtime, Env) {
-	
+
 	var type = 'html4', extensions = {};
 
 	function Html4Runtime(options) {
@@ -38,7 +38,7 @@ define("moxie/runtime/html4/Runtime", [
 			do_cors: false,
 			drag_and_drop: false,
 			filter_by_extension: Test(function() { // if you know how to feature-detect this, please suggest
-				return (Env.browser === 'Chrome' && Env.version >= 28) || (Env.browser === 'IE' && Env.version >= 10);
+				return (Env.browser === 'Chrome' && Env.version >= 28) || (Env.browser === 'IE' && Env.version >= 10) || (Env.browser === 'Safari' && Env.version >= 7);
 			}()),
 			resize_image: function() {
 				return extensions.Image && I.can('access_binary') && Env.can('create_canvas');
@@ -48,7 +48,7 @@ define("moxie/runtime/html4/Runtime", [
 			return_response_type: function(responseType) {
 				if (responseType === 'json' && !!window.JSON) {
 					return true;
-				} 
+				}
 				return !!~Basic.inArray(responseType, ['text', 'document', '']);
 			},
 			return_status_code: function(code) {

--- a/src/javascript/runtime/html5/Runtime.js
+++ b/src/javascript/runtime/html5/Runtime.js
@@ -22,9 +22,9 @@ define("moxie/runtime/html5/Runtime", [
 	"moxie/runtime/Runtime",
 	"moxie/core/utils/Env"
 ], function(Basic, x, Runtime, Env) {
-	
+
 	var type = "html5", extensions = {};
-	
+
 	function Html5Runtime(options) {
 		var I = this
 		, Test = Runtime.capTest
@@ -45,13 +45,13 @@ define("moxie/runtime/html5/Runtime", [
 					return (('draggable' in div) || ('ondragstart' in div && 'ondrop' in div)) && (Env.browser !== 'IE' || Env.version > 9);
 				}()),
 				filter_by_extension: Test(function() { // if you know how to feature-detect this, please suggest
-					return (Env.browser === 'Chrome' && Env.version >= 28) || (Env.browser === 'IE' && Env.version >= 10);
+					return (Env.browser === 'Chrome' && Env.version >= 28) || (Env.browser === 'IE' && Env.version >= 10) || (Env.browser === 'Safari' && Env.version >= 7);
 				}()),
 				return_response_headers: True,
 				return_response_type: function(responseType) {
 					if (responseType === 'json' && !!window.JSON) { // we can fake this one even if it's not supported
 						return true;
-					} 
+					}
 					return Env.can('return_response_type', responseType);
 				},
 				return_status_code: True,
@@ -67,8 +67,8 @@ define("moxie/runtime/html5/Runtime", [
 				},
 				select_multiple: function() {
 					// it is buggy on Safari Windows and iOS
-					return I.can('select_file') && 
-						!(Env.browser === 'Safari' && Env.os === 'Windows') && 
+					return I.can('select_file') &&
+						!(Env.browser === 'Safari' && Env.os === 'Windows') &&
 						!(Env.os === 'iOS' && Env.verComp(Env.osVersion, "7.0.4", '<'));
 				},
 				send_binary_string: Test(window.XMLHttpRequest && (new XMLHttpRequest().sendAsBinary || (window.Uint8Array && window.ArrayBuffer))),
@@ -87,7 +87,7 @@ define("moxie/runtime/html5/Runtime", [
 						!!~Basic.inArray(Env.browser, ['Chrome', 'Safari']);
 				}()),
 				upload_filesize: True
-			}, 
+			},
 			arguments[2]
 		);
 


### PR DESCRIPTION
Escape the madness of mime types by adding support for filtering by file extension to the html5 runtime!

This is part of the W3C spec, as documented here:
http://www.w3.org/TR/2012/WD-html5-20121025/states-of-the-type-attribute.html#attr-input-accept

At the moment only some browsers support filtering by extension (Safari, Chrome, IE10, IE11). But hopefully support for other browsers should be in the pipeline.