### PR TITLE
Add guard to setTimeout

### DIFF
--- a/src/javascript/runtime/RuntimeClient.js
+++ b/src/javascript/runtime/RuntimeClient.js
@@ -59,9 +59,12 @@ define('moxie/runtime/RuntimeClient', [
 
 						// jailbreak ...
 						setTimeout(function() {
-							runtime.clients++;
-							// this will be triggered on component
-							comp.trigger('RuntimeInit', runtime);
+							// runtime might have been destryed before init.
+							if (runtime) {
+								runtime.clients++;
+								// this will be triggered on component
+								comp.trigger('RuntimeInit', runtime);
+							}
 						}, 1);
 					});
 


### PR DESCRIPTION
As the runtime might have been destroyed before the function executes, causing errors.
