### PR TITLE
Add support for filesizes like 1.2m

### DIFF
--- a/src/javascript/core/utils/Basic.js
+++ b/src/javascript/core/utils/Basic.js
@@ -351,14 +351,14 @@ define('moxie/core/utils/Basic', [], function() {
 			},
 			mul;
 
-		size = /^([0-9]+)([mgk]?)$/.exec(size.toLowerCase().replace(/[^0-9mkg]/g, ''));
+		size = /^([0-9.]+)([mgk]?)$/.exec(size.toLowerCase().replace(/[^0-9.mkg]/g, ''));
 		mul = size[2];
 		size = +size[1];
 		
 		if (muls.hasOwnProperty(mul)) {
 			size *= muls[mul];
 		}
-		return size;
+		return ~~size;
 	};
 
 


### PR DESCRIPTION
Before this fix 1.2m would be interpreted as 12mb, which could cause all kind of issues. `~~` is used for stripping the decimal part, but `Math.floor(size)` or `parseInt(size, 10)` would work too.