### PR TITLE
Fix for clicking in Chromium

### DIFF
--- a/src/javascript/runtime/html5/Runtime.js
+++ b/src/javascript/runtime/html5/Runtime.js
@@ -84,7 +84,7 @@ define("moxie/runtime/html5/Runtime", [
 					return (Env.browser === 'Firefox' && Env.version >= 4) ||
 						(Env.browser === 'Opera' && Env.version >= 12) ||
 						(Env.browser === 'IE' && Env.version >= 10) ||
-						!!~Basic.inArray(Env.browser, ['Chrome', 'Safari']);
+						!!~Basic.inArray(Env.browser, ['Chrome', 'Chromium', 'Safari']);
 				}()),
 				upload_filesize: True
 			}, 


### PR DESCRIPTION
`Env.browser` contains `Chromium` in Chromium browser, which is true and correct, and prevents clicking from working since check fails (actually, Chromium behaves similar to Chrome and Safari in this situation, and that is why I've added it there).
