### PR TITLE
check if gapi.auth.getToken() is defined

### DIFF
--- a/src/javascript/runtime/googledrive/file/FileReader.js
+++ b/src/javascript/runtime/googledrive/file/FileReader.js
@@ -33,7 +33,7 @@ define("moxie/runtime/googledrive/file/FileReader", [
 				_xhr = new window.XMLHttpRequest();
 				_xhr.open('GET', blob.downloadUrl);
 				
-				if ('gapi' in window) {
+				if ('gapi' in window && gapi.auth.getToken()) {
 					_xhr.setRequestHeader('Authorization', 'Bearer ' + gapi.auth.getToken().access_token);
 				}
 


### PR DESCRIPTION
When using both googledrive and dropbox runtimes, if you first want to download dropbox file, you get gapi.auth.getToken() = undefined and JS error when trying to access gapi.auth.getToken().access_token.