### PR TITLE
Fix for url parser

### DIFF
--- a/src/javascript/core/utils/Url.js
+++ b/src/javascript/core/utils/Url.js
@@ -55,7 +55,7 @@ define('moxie/core/utils/Url', [], function() {
 				// if path ends with a filename, strip it
 				if (!/(\/|\/[^\.]+)$/.test(path)) {
 					path = path.replace(/\/[^\/]+$/, '/');
-				} else {
+				} else if (/\?!\//.test(path)) { //add slash only if there is none
 					path += '/';
 				}
 			}


### PR DESCRIPTION
If we have relative url "api/upload" and we are on site with url "http://example.com/test/#/item" it strips the path to "/test/" and then it adds additional slash which results in bad request. This change will help for that.