### PR TITLE
Remove a strange character from BinaryReader

### DIFF
--- a/src/javascript/runtime/html5/utils/BinaryReader.js
+++ b/src/javascript/runtime/html5/utils/BinaryReader.js
@@ -24,7 +24,6 @@ define("moxie/runtime/html5/utils/BinaryReader", [
 			UTF16StringReader.apply(this, arguments);
 		}
 	}
-	 
 
 	Basic.extend(BinaryReader.prototype, {
 		


### PR DESCRIPTION
There is an error from this line:
```
Uncaught ReferenceError: Â is not defined
```