### PR TITLE
Fix for the Cordova File plugin overriding FileReader.

### DIFF
--- a/bin/js/moxie.js
+++ b/bin/js/moxie.js
@@ -6939,6 +6939,10 @@ define("moxie/runtime/html5/file/FileReader", [
 
 				_fr = new window.FileReader();
 
+				if (_fr._realReader) {
+					_fr = _fr._realReader;
+				}
+
 				_fr.addEventListener('progress', function(e) {
 					comp.trigger(e);
 				});

--- a/src/javascript/runtime/html5/file/FileReader.js
+++ b/src/javascript/runtime/html5/file/FileReader.js
@@ -30,6 +30,10 @@ define("moxie/runtime/html5/file/FileReader", [
 
 				_fr = new window.FileReader();
 
+				if (_fr._realReader) {
+					_fr = _fr._realReader;
+				}
+
 				_fr.addEventListener('progress', function(e) {
 					comp.trigger(e);
 				});


### PR DESCRIPTION
If you use mOxie in a project that also includes Cordova and uses the Cordova File plugin, uploads will fail in Cordova environments. The issue is that the Cordova File plugin shims window.FileReader, and does not define `addEventListener` on it.
The real window.FileReader is exposed as FileReader._realReader, so for mOxie it is best to check if that is defined and then fallback to it.

This is probably too much of an edge-case to be included in mOxie, but it's worth mentioning in case anyone else has the same issue.
