### PR TITLE
#157 Memory leak in IE

### DIFF
--- a/src/javascript/runtime/html5/image/Image.js
+++ b/src/javascript/runtime/html5/image/Image.js
@@ -433,6 +433,10 @@ define("moxie/runtime/html5/image/Image", [
 				_imgInfo.purge();
 				_imgInfo = null;
 			}
+			//Memory issue for IE/Edge. They Keep a reference to image (because of the onload event) and the object not been collected by GC.
+			if (_img) {
+			    _img.src = '';
+			}
 			_binStr = _img = _canvas = _blob = null;
 			_modified = false;
 		}


### PR DESCRIPTION
Memory issue for IE/Edge. They Keep a reference to image (because of the onload event) and the object not been collected by GC.