### PR TITLE
Added Edge to list of browsers that support summon_file_dialog

### DIFF
--- a/src/javascript/runtime/html5/Runtime.js
+++ b/src/javascript/runtime/html5/Runtime.js
@@ -94,7 +94,7 @@ define("moxie/runtime/html5/Runtime", [
 						(Env.browser === 'Firefox' && Env.verComp(Env.version, 4, '>=')) ||
 						(Env.browser === 'Opera' && Env.verComp(Env.version, 12, '>=')) ||
 						(Env.browser === 'IE' && Env.verComp(Env.version, 10, '>=')) ||
-						!!~Basic.inArray(Env.browser, ['Chrome', 'Safari'])
+						!!~Basic.inArray(Env.browser, ['Chrome', 'Safari', 'Edge'])
 					);
 				},
 				upload_filesize: True,


### PR DESCRIPTION
Edge supports summon_file_dialog, as IE 10+ does, but that isn't detected by the UA check that you do. This adds Edge to the list of supported browsers, so that it works properly.