### PR TITLE
Fix a small typo in two docblocks

### DIFF
--- a/bin/js/moxie.js
+++ b/bin/js/moxie.js
@@ -347,7 +347,7 @@ define('moxie/core/utils/Basic', [], function() {
 	}
 
 	/**
-	Recieve an array of functions (usually async) to call in sequence, each  function
+	Receive an array of functions (usually async) to call in sequence, each  function
 	receives a callback as first argument that it should call, when it completes. Finally,
 	after everything is complete, main callback is called. Passing truthy value to the
 	callback as a first argument will interrupt the sequence and invoke main callback
@@ -382,7 +382,7 @@ define('moxie/core/utils/Basic', [], function() {
 
 
 	/**
-	Recieve an array of functions (usually async) to call in parallel, each  function
+	Receive an array of functions (usually async) to call in parallel, each  function
 	receives a callback as first argument that it should call, when it completes. After
 	everything is complete, main callback is called. Passing truthy value to the
 	callback as a first argument will interrupt the process and invoke main callback


### PR DESCRIPTION
I spotted them in WordPress vendor files and wanted to patch them upstream. Not an urgent thing, but worth fixing this one day or another :)